### PR TITLE
Spike code reuse faking testing

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,6 +14,7 @@ class HomeController < ApplicationController
   def fake
     params[:runs].each do |key, value|
       value[:environment] = params[:environment]
+      value[:display] = "browser"
       FakerJob.perform_now value
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,10 +4,6 @@ module ApplicationHelper
   end
 
   def interaction_types
-    @interaction_typs ||= interactions.keys
-  end
-
-  def environment_url(url, environment)
-    url.gsub("[ENVIRONMENT]", environment)
+    @interaction_types ||= interactions.keys
   end
 end

--- a/app/jobs/faker_job.rb
+++ b/app/jobs/faker_job.rb
@@ -5,49 +5,7 @@ class FakerJob < ApplicationJob
   queue_as :default
 
   def perform(options)
-    puts options.inspect
-    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-      'goog:chromeOptions': { args: %w(headless disable-gpu) }
-    )
-    driver = Selenium::WebDriver.for :chrome, capabilities: capabilities
-
-    begin
-      interaction_type = options[:interaction_type]
-      interactions = ApplicationController.helpers.interactions[interaction_type]
-
-      options[:iterations].to_i.times do
-        if interaction_type == "pageviews"
-          interactions["urls"].each do |url|
-            driver.get ApplicationController.helpers.environment_url(url, options[:environment])
-            ActionCable.server.broadcast 'faker_channel', find_event(driver, interaction_type).to_json
-          end
-        else
-          interactions["urls"].each do |url|
-            driver.get ApplicationController.helpers.environment_url(url, options[:environment])
-            clickables = driver.find_elements(class: interactions["class"])
-            clickables.each do |clickable|
-              clickable.click
-              ActionCable.server.broadcast 'faker_channel', find_event(driver, interaction_type).to_json
-            end
-          end
-        end
-      end
-    ensure
-      driver.quit
-    end
-  end
-
-  private
-
-  def find_event(driver, interaction_type)
-    events = driver.execute_script("return dataLayer")
-    events.each do |event|
-      if interaction_type == "pageviews"
-        return event if event["event"] == "config_ready"
-      else
-        return event if event["event"] == "analytics"
-      end
-    end
-    { error: "Unknown interaction type #{interaction_type}" }
+    faker_job = CreateEvents.new(options)
+    faker_job.run
   end
 end

--- a/app/models/concerns/interaction_concern.rb
+++ b/app/models/concerns/interaction_concern.rb
@@ -1,0 +1,23 @@
+module InteractionConcern
+  extend ActiveSupport::Concern
+
+  def interaction_data
+    ApplicationController.helpers.interactions
+  end
+
+  def find_interactions_by_type
+    interactions[interaction_type]
+  end
+
+  def find_interaction_class
+    find_interactions_by_type["class"]
+  end
+
+  def find_interaction_urls
+    find_interactions_by_type["urls"]
+  end
+
+  def environment_url(url, environment)
+    url.gsub("[ENVIRONMENT]", environment)
+  end
+end

--- a/app/models/create_events.rb
+++ b/app/models/create_events.rb
@@ -1,0 +1,61 @@
+class CreateEvents < GoogleTagManager
+  def initialize(options)
+    super
+  end
+
+  def run
+    events_output_to_file
+  end
+
+  private
+
+  def create_events
+    begin
+      if interaction_type == "pageviews"
+        find_interaction_urls.each do |url|
+          iterations.to_i.times do
+            get_url(url)
+            output_event_data
+          end
+        end
+      else
+        find_interaction_urls.each do |url|
+          iterations.to_i.times do
+            get_url(url)
+            clickables.each do |clickable|
+              clickable.click
+              output_event_data
+            end
+          end
+        end
+      end
+    ensure
+      driver.quit
+    end
+  end
+
+  def output_event_data
+    @output_file.puts get_event
+    @output_file.puts "\n"
+  end
+
+  def events_output_to_file
+    begin
+      @output_file = File.open("log/#{Time.now.strftime('%Y-%m-%d-%H-%M-%S')}.log", "w")
+      create_events
+    ensure
+      @output_file.close
+    end
+  end
+
+  def get_event
+    events.each do |event|
+      if interaction_type == "pageviews"
+        return event if event["event"] == "config_ready"
+      else
+        return event if event["event"] == "analytics"
+      end
+    end
+    { error: "Unknown interaction type #{interaction_type}" }.to_json
+  end
+end

--- a/app/models/create_events.rb
+++ b/app/models/create_events.rb
@@ -4,7 +4,11 @@ class CreateEvents < GoogleTagManager
   end
 
   def run
-    events_output_to_file
+    if display == "browser"
+      create_events
+    else
+      events_output_to_file
+    end
   end
 
   private
@@ -35,8 +39,12 @@ class CreateEvents < GoogleTagManager
   end
 
   def output_event_data
-    @output_file.puts get_event
-    @output_file.puts "\n"
+    if display == "browser"
+      ActionCable.server.broadcast 'faker_channel', get_event.to_json
+    else
+      @output_file.puts get_event
+      @output_file.puts "\n"
+    end
   end
 
   def events_output_to_file

--- a/app/models/google_tag_manager.rb
+++ b/app/models/google_tag_manager.rb
@@ -1,0 +1,29 @@
+require "webdrivers"
+require "yaml"
+require "fileutils"
+
+class GoogleTagManager
+  attr_reader :options, :interactions, :driver, :output_file
+
+  def initialize(options)
+    @options = options
+    @interactions = interaction_data
+    @capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+      "goog:chromeOptions": { args: %w(headless disable-gpu) }
+    )
+    @driver = Selenium::WebDriver.for :chrome, capabilities: @capabilities
+    FileUtils.mkdir_p "log"
+  end
+
+  def environment
+    options[:environment]
+  end
+
+  def interaction_type
+    options[:interaction_type]
+  end
+
+  def iterations
+     options[:iterations] ||= 1
+  end
+end

--- a/app/models/google_tag_manager.rb
+++ b/app/models/google_tag_manager.rb
@@ -3,6 +3,7 @@ require "yaml"
 require "fileutils"
 
 class GoogleTagManager
+  include InteractionConcern
   attr_reader :options, :interactions, :driver, :output_file
 
   def initialize(options)

--- a/app/models/google_tag_manager.rb
+++ b/app/models/google_tag_manager.rb
@@ -27,4 +27,17 @@ class GoogleTagManager
   def iterations
      options[:iterations] ||= 1
   end
+
+  def clickables
+    driver.find_elements(class: find_interaction_class)
+  end
+
+  def events
+    driver.execute_script("return dataLayer")
+  end
+
+  def get_url(url)
+    url = environment_url(url, environment)
+    driver.get url
+  end
 end

--- a/app/models/google_tag_manager.rb
+++ b/app/models/google_tag_manager.rb
@@ -40,4 +40,8 @@ class GoogleTagManager
     url = environment_url(url, environment)
     driver.get url
   end
+
+  def display
+    options[:display]
+  end
 end

--- a/app/models/test_events.rb
+++ b/app/models/test_events.rb
@@ -1,0 +1,90 @@
+class TestEvents < GoogleTagManager
+  def initialize(options)
+    super
+  end
+
+  def run
+    tester
+  end
+
+  private
+
+  def tester
+    begin
+      find_interaction_urls.each do |url|
+        iterations.to_i.times do
+          get_url(url)
+          clickables.each do |clickable|
+            if interaction_type == "tabs"
+              test_tab_events(clickable)
+            elsif interaction_type == "accordions"
+              test_accordion_events(clickable)
+            end
+          end
+        end
+      end
+    ensure
+      driver.quit
+    end
+  end
+
+  def event_name(clickable)
+    clickable.attribute("data-gtm-event-name")
+  end
+
+  def data_attributes(clickable)
+    JSON.parse(clickable.attribute("data-gtm-attributes"))
+  end
+
+  def test_result(expected_event)
+    puts events.last == expected_event ? "😀" : "🤮 : #{diff_events(events.last, expected_event)}"
+  end
+
+  def test_tab_events(tab)
+    tab.click
+
+    expected_event = create_event(event_name(tab), events.length, data_attributes(tab), data_attributes(tab)["state"])
+    test_result(expected_event)
+  end
+
+  def test_accordion_events(accordion)
+    %w[opened closed].each do |state|
+      accordion.click
+
+      expected_event = create_event(event_name(accordion), events.length, data_attributes(accordion), state)
+      test_result(expected_event)
+    end
+  end
+
+  def current_url
+    uri = URI.parse(driver.current_url)
+    if uri.fragment
+      "#{uri.path}##{uri.fragment}"
+    else
+      "#{uri.path}"
+    end
+  end
+
+  def create_event(event_name, id, data_attributes, state)
+    {
+      "event" => "analytics",
+      "event_name" => event_name,
+      "gtm.uniqueEventId" => id,
+      "link_url" => current_url,
+      "ui" => {
+        "index" => data_attributes["index"],
+        "index-total" => data_attributes["index-total"],
+        "section" => data_attributes["section"],
+        "action" => state,
+        "text" => data_attributes["text"],
+        "type" => data_attributes["type"]
+      }
+    }
+  end
+
+  def diff_events(event_a, event_b)
+    Hash[*(
+      (event_b.size > event_a.size) ? event_b.to_a - event_a.to_a : event_a.to_a - event_b.to_a
+    ).flatten]
+  end
+end

--- a/lib/tasks/check_events.rake
+++ b/lib/tasks/check_events.rake
@@ -1,0 +1,33 @@
+desc 'Check event data is as expected'
+task :check_events, [:action, :environment, :interaction_type, :iterations] => :environment do |_, args|
+  # Example: bundle exec rake check_events[create,integration,accordions,2]
+  validate_args(args)
+
+  options = {
+    action: args[:action],
+    environment: args[:environment],
+    interaction_type: args[:interaction_type],
+    iterations: args[:iterations]
+  }
+
+  klass = if options[:action] == "create"
+    # Output events to a file
+    CreateEvents.new(options)
+  elsif options[:action] == "test"
+    # Diff events against the expected event structure 
+    TestEvents.new(options)
+  else
+    "Invalid action param - Must be 'test' or 'create"
+    exit
+  end
+
+  klass.run
+
+  puts "Done!"
+end
+
+def validate_args(args)
+  raise ArgumentError, "Invalid action param - Must be 'test' or 'create'" unless ["test", "create"].include? args[:action]
+  raise ArgumentError, "Invalid environment param - Must be 'integration' or 'staging'" unless ["integration", "staging"].include? args[:environment]
+  raise ArgumentError, "Invalid interaction_type param - Must be 'tabs' or 'accordions' or 'pageviews'" unless ["tabs", "accordions", "pageviews"].include? args[:interaction_type]
+end


### PR DESCRIPTION
This is a spike into an approach for refactoring the `test` and `fake` code from the [gtm-utils repo](https://github.com/gclssvglx/gtm-utils/blob/main/google_tag_manager.rb), moving it into this repo and then refactoring the `fake` code to be used by `FakerJob` in this repo. 

The 'test' code diffs the events fired with an expected event structure and outputs (to the console) whether the fired-event structure is correct. The longer term goal is to run this daily (potentially as a Jenkins job). The 'create' code will output the events fired to a text file or to the browser. This could be extended to specify whether test/fake output should be outputted to a file OR the console. I don't really know if this is worthwhile for the tests as they will probably run from a Jenkins job so we will want to see the console output, but might be useful for the faking code. 

I spoke to Graham about the naming and we decided we will stick with `Fake` as opposed to `Create` to in-keep with gems such as 'faker' in which real events are generated. I initially used `create` as I thought `fake` might be confusing as the events fired are real, but actually fake in this context refers to imitating the user journey.  Therefore I will update the naming in `CreateEvent` to change to `FakeEvent`. 

I used inheritance for code reuse. Inheritance [is typically used](https://engineering.entelo.com/understanding-inheritance-and-composition-in-ruby-edc46c0f96c7#:~:text=Inheritance%20is%20a%20great%20choice,up%20functionality%20into%20distinct%20responsibilities.) for an `is_a?` relationship (Apple is a Fruit type thing). The GTM class is a bit less of an obvious 'thing', it's more of an interface between the inputs and GTM.  I envisioned the GTM as a GoogleTagManager events model and then the children are different processes that can be performed on the events. Another approach to code reuse is composition which implements a `has_a?` relationship. This could be more fitting as `test` could have a tag manager and so could `create`. I tried this out (Figure 1,2) but thought that inheritance was a bit cleaner, though I realise this could be considered a bit controversial:

![composition-example](https://user-images.githubusercontent.com/5963488/179231989-3bb61acd-7c3f-4a35-a18b-10982aced2f1.png)
Figure 1

![composition-example-continued](https://user-images.githubusercontent.com/5963488/179236610-f62f5727-2a63-4fa1-9964-4a3cade3f018.png)
Figure 2

Let me know which you prefer, if any!

The tabs tests fail due to the URLs not being as expected. This is a known implementation error (in the frontend... outside of this repo), so this code will need to be re-visited when that implementation is fixed. I updated the comparison to compare against the url path and the fragment. This is because it should compare whether `bank-holidays#scotland` is as expected... otherwise it just compares `bank-holidays` which they all have.

There was also a bug in the original implementation of `FakerJob`, in that the same event is returned X amount of times:

Tabs
```
{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/renew-driving-licence", "ui"=>{"action"=>"n/a", "index"=>1, "index-total"=>2, "section"=>"n/a", "text"=>"More information", "type"=>"tabs"}}

{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/renew-driving-licence", "ui"=>{"action"=>"n/a", "index"=>1, "index-total"=>2, "section"=>"n/a", "text"=>"More information", "type"=>"tabs"}}

{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/bank-holidays", "ui"=>{"action"=>"n/a", "index"=>0, "index-total"=>3, "section"=>"n/a", "text"=>"England and Wales", "type"=>"tabs"}}

{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/bank-holidays", "ui"=>{"action"=>"n/a", "index"=>0, "index-total"=>3, "section"=>"n/a", "text"=>"England and Wales", "type"=>"tabs"}}

{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/bank-holidays", "ui"=>{"action"=>"n/a", "index"=>0, "index-total"=>3, "section"=>"n/a", "text"=>"England and Wales", "type"=>"tabs"}}
```

Accordions
```
{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/coronavirus", "ui"=>{"action"=>"opened", "index"=>1, "index-total"=>5, "section"=>"n/a", "text"=>"Staying safe", "type"=>"accordion"}}

{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/coronavirus", "ui"=>{"action"=>"opened", "index"=>1, "index-total"=>5, "section"=>"n/a", "text"=>"Staying safe", "type"=>"accordion"}}

{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/coronavirus", "ui"=>{"action"=>"opened", "index"=>1, "index-total"=>5, "section"=>"n/a", "text"=>"Staying safe", "type"=>"accordion"}}

{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/coronavirus", "ui"=>{"action"=>"opened", "index"=>1, "index-total"=>5, "section"=>"n/a", "text"=>"Staying safe", "type"=>"accordion"}}

{"event"=>"analytics", "event_name"=>"select_content", "gtm.uniqueEventId"=>5, "link_url"=>"/coronavirus", "ui"=>{"action"=>"opened", "index"=>1, "index-total"=>5, "section"=>"n/a", "text"=>"Staying safe", "type"=>"accordion"}}
```

I didn't try and fix this as part of the spike and just focused on refactoring. This avoidance is also because there are other changes happening to the data structure at the moment, so I thought it would be better to wait for that to be agreed before trying to fix it, to save having to do it twice. The right events did seem to be firing in the browser on integration so I think it's a bug in this tool. I should also mention that the changes to the data structure will also mean the test code will need updating. 

TODO if this seems like a good approach:
- Tests
- Change `create` naming to `fake`
- The rake task could be made a bit more robust. At the moment it breaks if there are spaces.
- Fix the test and fake output code against the updated data structure

To review
Example command: `bundle exec rake check_events[create,integration,accordions]`
You need to be connected to the VPN. 

Browser: `bundle exec rails s` and navigate to http://localhost:3000/?env=integration&runs[]=pageviews:1&runs[]=tabs:2&runs[]=accordions:3